### PR TITLE
fix(ci): fix e2e tests on ci

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,8 +10,6 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@v4
-      with:
-        cache: true
     - uses: actions/setup-node@v6
       with:
         node-version-file: .node-version

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  DO_NOT_TRACK: 1
+
 jobs:
   test-lint:
     name: Test and lint

--- a/apps/example/tsdown.config.ts
+++ b/apps/example/tsdown.config.ts
@@ -19,5 +19,8 @@ export default defineConfig([
 		target: ["node24", "chrome130"],
 		noExternal: [/@kavsingh/],
 		format: ["cjs"],
+		// tsdown warns on cjs builds which are required for preload scripts
+		// this warning becomes an error on CI which blocks E2E
+		failOnWarn: false,
 	},
 ]);


### PR DESCRIPTION
This pull request introduces minor configuration updates to improve the developer experience and CI reliability. The most notable changes are the addition of an environment variable to disable tracking during workflow runs, and the suppression of warnings in the `tsdown` configuration to prevent CI failures.

**CI and workflow improvements:**

* Added the `DO_NOT_TRACK=1` environment variable to the `test-lint` GitHub Actions workflow to disable tracking during CI runs.
* Removed the invalid `cache: true` option from the `pnpm/action-setup`

**Build configuration:**

* Set `failOnWarn: false` in the `tsdown.config.ts` file for the example app to prevent warnings in CommonJS builds from causing CI failures when building the electron preload script.